### PR TITLE
chore: change secret name for npm token

### DIFF
--- a/.github/workflows/publishprerelease.yml
+++ b/.github/workflows/publishprerelease.yml
@@ -29,14 +29,14 @@ jobs:
       - run: npm run test:anvil
       - uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          token: ${{ secrets.FHEVM_NPM_TOKEN }}
           package: packages/mock-utils/src
           provenance: true
           tag: prerelease
           access: public
       - uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          token: ${{ secrets.FHEVM_NPM_TOKEN }}
           package: packages/hardhat-plugin
           provenance: true
           tag: prerelease


### PR DESCRIPTION
I unify token usage across fhevm repositories.